### PR TITLE
Fix custom loading example code

### DIFF
--- a/ko/api/configuration-loading.md
+++ b/ko/api/configuration-loading.md
@@ -104,6 +104,6 @@ export default {
 
 ```js
 module.exports = {
-  loading: '~components/loading.vue'
+  loading: '~/components/loading.vue'
 }
 ```


### PR DESCRIPTION
`/ko.docs.nuxtjs/blob/translation-ko/ko/api/configuration-loading.md`
이 부분 예제 코드를 실제로 적용해보니
```
module.exports = {
  loading: '~components/loading.vue'
}
```
이 아니라
```
module.exports = {
  loading: '~/components/loading.vue'
}
```
으로 해야 작동되는 것을 확인했습니다.